### PR TITLE
fix: allow text input for magic identifier field

### DIFF
--- a/src/components/LoginPage/LoginForm.tsx
+++ b/src/components/LoginPage/LoginForm.tsx
@@ -104,6 +104,7 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
                 id="identifier"
                 name="identifier"
                 type="text"
+                inputMode="text"
                 required
                 value={identifier}
                 onChange={(e) => setIdentifier(e.target.value)}


### PR DESCRIPTION
## Summary
- allow free-form entry on the magic link identifier field by switching the identifier input mode to text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da333f27348323bae4f2c8a28a5983

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a397993174473c1951583c224e6047d9c8d0e822. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->