### PR TITLE
Revamp mobile dashboard layout

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Calendar, Users, BookOpen, TrendingUp, Award, Shield, MapPin, Link as LinkIcon, Video, CalendarDays, Users2, CheckCircle2, Info, Play, Pause, Loader2, XCircle, RefreshCw } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { LucideIcon } from 'lucide-react';
+import { Calendar, Users, BookOpen, TrendingUp, Award, Shield, MapPin, Link as LinkIcon, Video, CalendarDays, Users2, CheckCircle2, Info, Play, Pause, Loader2, XCircle, RefreshCw, Sparkles, ArrowRight, ClipboardList, Clock } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { getDeclension } from '../utils/textUtils';
 import { getCachedEvents, setCachedEvents, clearEventsCache } from '../lib/eventsCache';
@@ -19,6 +21,7 @@ interface EventWithDetails extends Event {
 
 // Карточка мероприятия (как в EventsView)
 function EventCard({ event }: { event: EventWithDetails }) {
+  const { userProfile } = useAuth();
   // Парсинг даты
   const parseDate = (event: EventWithDetails) => {
     const base = event.start_date || event.date_time || event.created_at || '';
@@ -27,6 +30,17 @@ function EventCard({ event }: { event: EventWithDetails }) {
   };
   
   const d = parseDate(event);
+  const role = userProfile?.role;
+  const isExpert = role === 'expert';
+  const isAdmin = role === 'administrator';
+  const expertEmails = Array.isArray(event.expert_emails) ? event.expert_emails : [];
+  const isExamTalentReserve = event.event_type?.name === 'exam_talent_reserve';
+  const isExpertAssigned = isExpert && expertEmails.includes(userProfile?.email || '');
+  const shouldOpenExam = isExamTalentReserve && (isAdmin || isExpertAssigned);
+
+  if (isExpert && !shouldOpenExam) {
+    return null;
+  }
   
   // Статус мероприятия
   const STATUS_MAP = {
@@ -113,121 +127,86 @@ function EventCard({ event }: { event: EventWithDetails }) {
   
   return (
     <article
-      className="group relative overflow-hidden rounded-3xl bg-white/80 backdrop-blur-sm border border-slate-200/50 p-5 shadow-sm hover:shadow-lg hover:shadow-slate-200/50 transition-all duration-300 flex flex-col h-full hover:scale-[1.02] hover:border-slate-300/60"
+      className="group relative min-w-[260px] sm:min-w-0 overflow-hidden rounded-3xl border border-white/40 bg-white/70 backdrop-blur-xl p-5 shadow-[0_24px_60px_-40px_rgba(15,23,42,0.65)] transition-all duration-300 flex flex-col h-full hover:-translate-y-1 hover:shadow-[0_32px_60px_-30px_rgba(15,23,42,0.35)]"
     >
-      {/* Верх: дата-время + статус/тип */}
-      <header className="mb-3 flex items-start justify-between gap-3 flex-shrink-0">
-        <div className="flex flex-col gap-2 min-w-0">
-          <div className="flex flex-col gap-2">
-            {/* Статус */}
-            <div className="flex flex-wrap items-center gap-2">
-              {(() => {
-                const { userProfile } = useAuth();
-                const isExpert = userProfile?.role === 'expert';
-                
-                // Для экспертов не показываем статус
-                if (isExpert) {
-                  return null;
-                }
-                
-                const isIconOnly = !label;
-                const badgeClass = `inline-flex items-center gap-1 text-[10px] font-semibold ring-1 shadow-sm ${
-                  isIconOnly ? 'h-7 w-7 justify-center rounded-lg p-0' : 'rounded-full px-2 py-0.5'
-                } ${statusTone} ${ring}`;
-                const iconSize = isIconOnly ? 'h-4 w-4' : 'h-3.5 w-3.5';
-
-                return (
-                  <span className={badgeClass}>
-                    <StatusIcon className={`${iconSize} ${event.status === 'ongoing' && 'animate-spin'}`} />
-                    {!isIconOnly && <span>{label}</span>}
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(6,164,120,0.08),transparent_65%)] opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+      <div className="relative flex flex-col h-full">
+        {/* Верх: дата-время + статус/тип */}
+        <header className="mb-4 flex items-start justify-between gap-3 flex-shrink-0">
+          <div className="flex flex-col gap-3 min-w-0">
+            <div className="flex flex-col gap-2">
+              {/* Статус */}
+              <div className="flex flex-wrap items-center gap-2">
+                {!isExpert && (
+                  <span
+                    className={`inline-flex items-center gap-1.5 text-[10px] font-semibold ring-1 shadow-sm ${
+                      !label ? 'h-7 w-7 justify-center rounded-lg p-0' : 'rounded-full px-2 py-1'
+                    } ${statusTone} ${ring}`}
+                  >
+                    <StatusIcon className={`${!label ? 'h-4 w-4' : 'h-3.5 w-3.5'} ${event.status === 'ongoing' && 'animate-spin'}`} />
+                    {label && <span>{label}</span>}
                   </span>
-                );
-              })()}
+                )}
+                <span className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1 text-[11px] font-semibold ring-1 shadow-sm ${getTypeChipClasses(event.type || 'other', event.event_type?.name)}`}>
+                  <TypeIcon className="h-3.5 w-3.5" />
+                  {typeInfo.label}
+                </span>
+              </div>
             </div>
-            
-            {/* Тип мероприятия */}
-            <div className="flex items-center gap-2">
-              <span className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1 text-[11px] font-semibold ring-1 shadow-sm ${getTypeChipClasses(event.type || 'other', event.event_type?.name)}`}>
-                <TypeIcon className="h-3.5 w-3.5" />
-                {typeInfo.label}
-              </span>
-            </div>
+
+            {/* Название */}
+            <h3 className="text-lg font-semibold leading-tight text-slate-900">
+              {event.title}
+            </h3>
+            {event.location && (
+              <div className="flex items-center gap-1.5 text-xs font-medium text-slate-500">
+                <MapPin className="h-3.5 w-3.5" />
+                <span className="truncate">{event.location}</span>
+              </div>
+            )}
           </div>
 
-          {/* Название */}
-          <h3 className="text-lg font-bold leading-tight text-slate-900">
-            {event.title}
-          </h3>
-        </div>
-
-        {/* Правый – акцент на дате/времени */}
-        <div className="shrink-0 w-[112px]">
-          <DateAccent date={d} />
-        </div>
-      </header>
-
-      {/* Описание */}
-      <div className="flex-1">
-        {event.description && (
-          <div className="mb-4 rounded-2xl bg-slate-50/60 backdrop-blur-sm p-4 border border-slate-200/40 shimmer-text">
-            <p className="line-clamp-3 text-sm leading-relaxed text-slate-600 whitespace-pre-line">
-              {event.description}
-            </p>
+          {/* Правый – акцент на дате/времени */}
+          <div className="shrink-0 w-[112px]">
+            <DateAccent date={d} />
           </div>
-        )}
-      </div>
+        </header>
+
+        {/* Описание */}
+        <div className="flex-1">
+          {event.description && (
+            <div className="mb-4 rounded-2xl bg-slate-50/60 backdrop-blur-sm p-4 border border-slate-200/40">
+              <p className="line-clamp-3 text-sm leading-relaxed text-slate-600 whitespace-pre-line">
+                {event.description}
+              </p>
+            </div>
+          )}
+        </div>
       
-      {/* Низ: действия */}
-      <footer className="mt-auto flex-shrink-0">
-        {(() => {
-          const { userProfile } = useAuth();
-          const isExpert = userProfile?.role === 'expert';
-          const isAdmin = userProfile?.role === 'administrator';
-          const isExamTalentReserve = event.event_type?.name === 'exam_talent_reserve';
-          const isExpertForThisExam = (isExpert || isAdmin) && isExamTalentReserve && (event.expert_emails?.includes(userProfile?.email || '') || isAdmin);
-          
-          // Для администраторов: если это экзамен, показываем кнопку "Оценить"
-          if (isAdmin && isExamTalentReserve) {
-            return (
-              <button 
-                onClick={() => window.location.href = `/expert-exam/${event.id}`}
-                className="w-full justify-center relative overflow-hidden bg-gradient-to-r from-[#06A478] to-[#059669] hover:from-[#059669] hover:to-[#047857] text-white font-medium py-3 px-4 rounded-2xl transition-all duration-300 shadow-sm hover:shadow-md hover:shadow-[#06A478]/25 focus:outline-none focus:ring-2 focus:ring-[#06A478]/20 focus:ring-offset-2 group"
-                title="Перейти к оценке"
-              >
-                <span className="text-sm font-medium relative z-10 group-hover:scale-105 transition-transform duration-200">Перейти к оценке</span>
-              </button>
-            );
-          }
-          
-          // Для экспертов, назначенных на конкретный экзамен
-          if (isExpertForThisExam) {
-            return (
-              <button 
-                onClick={() => window.location.href = `/expert-exam/${event.id}`}
-                className="w-full justify-center relative overflow-hidden bg-gradient-to-r from-[#06A478] to-[#059669] hover:from-[#059669] hover:to-[#047857] text-white font-medium py-3 px-4 rounded-2xl transition-all duration-300 shadow-sm hover:shadow-md hover:shadow-[#06A478]/25 focus:outline-none focus:ring-2 focus:ring-[#06A478]/20 focus:ring-offset-2 group"
-                title="Перейти к оценке"
-              >
-                <span className="text-sm font-medium relative z-10 group-hover:scale-105 transition-transform duration-200">Перейти к оценке</span>
-              </button>
-            );
-          }
-          
-          // Для экспертов не показываем кнопку
-          if (isExpert) {
-            return null;
-          }
-          
-          return (
-            <button 
-              onClick={() => window.location.href = `/event/${event.id}`}
-              className="w-full justify-center relative overflow-hidden bg-gradient-to-r from-slate-600 to-slate-700 hover:from-slate-700 hover:to-slate-800 text-white font-medium py-3 px-4 rounded-2xl transition-all duration-300 shadow-sm hover:shadow-md hover:shadow-slate-500/25 focus:outline-none focus:ring-2 focus:ring-slate-500/20 focus:ring-offset-2 group"
-              title="Открыть"
-            >
-              <span className="text-sm font-medium relative z-10 group-hover:scale-105 transition-transform duration-200">Открыть</span>
-            </button>
-          );
-        })()}
-      </footer>
+        {/* Низ: действия */}
+        <footer className="mt-auto flex-shrink-0">
+          <button
+            onClick={() => {
+              if (shouldOpenExam) {
+                window.location.href = `/expert-exam/${event.id}`;
+              } else {
+                window.location.href = `/event/${event.id}`;
+              }
+            }}
+            className={`group/button w-full justify-center relative overflow-hidden ${
+              shouldOpenExam
+                ? 'bg-gradient-to-r from-[#0EA47A] via-[#06A478] to-[#059669] text-white hover:from-[#059669] hover:to-[#047857]'
+                : 'bg-slate-900 text-white hover:bg-slate-800'
+            } font-medium py-3 px-4 rounded-2xl transition-all duration-300 shadow-sm hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#0EA47A]/30`}
+            title={shouldOpenExam ? 'Перейти к оценке' : 'Открыть событие'}
+          >
+            <span className="relative z-10 inline-flex items-center justify-center gap-2 text-sm font-medium">
+              {shouldOpenExam ? 'Перейти к оценке' : 'Открыть событие'}
+              <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover/button:translate-x-0.5" />
+            </span>
+          </button>
+        </footer>
+      </div>
     </article>
   );
 }
@@ -247,16 +226,53 @@ function StatsCard({
   icon: React.ReactNode;
 }) {
   return (
-    <div className="bg-white rounded-2xl shadow p-4 flex flex-col gap-2 items-start">
-      <div className="flex items-center gap-2 text-sns-500">{icon}</div>
-      <div className="text-2xl font-bold text-gray-900">{value}</div>
-      <div className="text-sm text-gray-500">{title}</div>
-      {change && (
-        <div className={`text-xs mt-1 ${changeType === 'positive' ? 'text-green-600' : 'text-red-600'}`}>
-          {change}
-        </div>
-      )}
+    <div className="relative min-w-[180px] md:min-w-0 overflow-hidden rounded-3xl border border-white/40 bg-white/70 backdrop-blur-xl px-5 py-4 shadow-[0_24px_60px_-40px_rgba(15,23,42,0.6)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_30px_60px_-35px_rgba(15,23,42,0.35)]">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.12),transparent_55%)] opacity-0 transition-opacity duration-500 hover:opacity-100" />
+      <div className="relative flex flex-col gap-3 text-left">
+        <div className="flex items-center gap-2 text-slate-500">{icon}</div>
+        <div className="text-2xl font-semibold text-slate-900">{value}</div>
+        <div className="text-sm font-medium text-slate-500">{title}</div>
+        {change && (
+          <div className={`text-xs font-semibold ${changeType === 'positive' ? 'text-emerald-600' : 'text-rose-500'}`}>
+            {change}
+          </div>
+        )}
+      </div>
     </div>
+  );
+}
+
+type QuickAction = {
+  id: string;
+  title: string;
+  subtitle: string;
+  to: string;
+  icon: LucideIcon;
+  accent: string;
+};
+
+function QuickActionCard({ action }: { action: QuickAction }) {
+  const Icon = action.icon;
+  return (
+    <Link
+      to={action.to}
+      className="group relative min-w-[200px] sm:min-w-[220px] overflow-hidden rounded-[26px] border border-white/50 bg-white/60 px-5 py-4 backdrop-blur-xl shadow-[0_24px_60px_-40px_rgba(15,23,42,0.55)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_30px_60px_-35px_rgba(15,23,42,0.3)]"
+    >
+      <span className={`absolute inset-0 bg-gradient-to-br ${action.accent} opacity-0 group-hover:opacity-100 transition-opacity duration-500`} />
+      <span className="absolute inset-0 bg-white/60 group-hover:bg-white/30 transition-colors duration-500" />
+      <span className="relative z-10 flex flex-col gap-4">
+        <span className="flex items-center justify-between">
+          <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 group-hover:text-slate-900">
+            <Icon className="h-4 w-4" />
+            {action.title}
+          </span>
+          <ArrowRight className="h-4 w-4 text-slate-400 transition-transform duration-300 group-hover:translate-x-0.5 group-hover:text-slate-900" />
+        </span>
+        <span className="text-xs text-slate-500 group-hover:text-slate-700 leading-snug">
+          {action.subtitle}
+        </span>
+      </span>
+    </Link>
   );
 }
 
@@ -480,160 +496,243 @@ export function DashboardView() {
     }
   }, [user, userProfile]);
 
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="flex flex-col items-center">
-          <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mb-4"></div>
-          <p className="text-gray-600">Загрузка данных пользователя...</p>
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-8 h-8 border-[3px] border-emerald-500 border-t-transparent rounded-full animate-spin"></div>
+          <p className="text-slate-500 text-sm font-medium">Загружаем ваш дашборд…</p>
         </div>
       </div>
     );
   }
 
+  const role = userProfile?.role;
+
+  const quickActions = useMemo<QuickAction[]>(() => {
+    const items: QuickAction[] = [
+      {
+        id: 'events',
+        title: 'Расписание',
+        subtitle: 'Все ближайшие тренинги и встречи',
+        to: '/events',
+        icon: CalendarDays,
+        accent: 'from-emerald-400/40 via-emerald-500/30 to-sky-400/40'
+      },
+      {
+        id: 'calendar',
+        title: 'Календарь',
+        subtitle: 'Смотрите неделю по дням',
+        to: '/calendar',
+        icon: Clock,
+        accent: 'from-sky-400/40 via-indigo-400/30 to-violet-400/40'
+      }
+    ];
+
+    if (role === 'expert') {
+      items.push({
+        id: 'expert-schedule',
+        title: 'Экспертиза',
+        subtitle: 'Ваши кейсы и расписание оценок',
+        to: '/expert-schedule',
+        icon: Sparkles,
+        accent: 'from-amber-300/40 via-orange-300/30 to-pink-300/40'
+      });
+    } else {
+      items.push({
+        id: 'testing',
+        title: 'Тесты',
+        subtitle: 'Продолжите обучение и проверьте прогресс',
+        to: '/testing',
+        icon: ClipboardList,
+        accent: 'from-emerald-300/40 via-emerald-400/30 to-teal-400/40'
+      });
+    }
+
+    if (role && ['administrator', 'moderator', 'trainer'].includes(role)) {
+      items.push({
+        id: 'team',
+        title: 'Команда',
+        subtitle: 'Статусы сотрудников и представители',
+        to: '/employees',
+        icon: Users2,
+        accent: 'from-blue-300/40 via-cyan-300/30 to-emerald-300/40'
+      });
+    }
+
+    return items;
+  }, [role]);
+
   return (
-    <div className="space-y-6 pb-24 md:pb-8 pb-safe-bottom">
-      {/* Welcome Section */}
-      <section className="bg-gradient-to-br from-[#06A478] via-[#059669] to-[#047857] rounded-3xl p-6 sm:p-8 text-white shadow-lg relative overflow-hidden">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h1 className="text-xl sm:text-2xl font-semibold mb-2 text-white">
-              {getGreeting()}, {extractFirstName(userProfile?.full_name || 'Пользователь')}
-            </h1>
-            <p className="text-white/90 text-sm sm:text-base mb-3 leading-relaxed">
-              {motivationalMessage}
-            </p>
-            <div className="flex items-center space-x-2 text-white/80 text-xs">
-              <Shield size={14} />
-              <span className="font-medium">
-                Ваша роль - {userProfile?.role ? USER_ROLE_LABELS[userProfile.role] : 'Не определена'}
-              </span>
+    <div className="relative pb-28 md:pb-12 pb-safe-bottom">
+      <div className="absolute inset-x-0 -top-24 h-56 bg-[radial-gradient(circle_at_top,_rgba(14,116,144,0.22),transparent_65%)] blur-3xl" />
+      <div className="absolute inset-x-0 top-40 h-72 bg-[radial-gradient(circle_at_center,_rgba(6,164,120,0.12),transparent_70%)] blur-2xl" />
+
+      <div className="relative z-10 flex flex-col gap-8">
+        <section className="relative -mx-4 sm:-mx-6 lg:-mx-8 overflow-hidden rounded-[32px] border border-white/20 bg-gradient-to-br from-[#0EA47A] via-[#0C8E6F] to-[#066247] px-5 py-6 sm:px-8 sm:py-10 text-white shadow-[0_40px_80px_-50px_rgba(8,47,35,0.8)]">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.28),transparent_55%)]" />
+          <div className="absolute -top-16 right-0 h-48 w-48 rounded-full bg-emerald-300/40 blur-3xl" />
+          <div className="absolute bottom-0 -left-20 h-56 w-56 rounded-full bg-emerald-500/30 blur-3xl" />
+          <div className="relative flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-4">
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-white/70">
+                <Sparkles className="h-3.5 w-3.5" />
+                Сегодня
+              </div>
+              <div className="space-y-3">
+                <h1 className="text-2xl sm:text-3xl font-semibold leading-tight">
+                  {getGreeting()}, {extractFirstName(userProfile?.full_name || 'Пользователь')}!
+                </h1>
+                <p className="max-w-xl text-sm sm:text-base text-white/80 leading-relaxed">
+                  {motivationalMessage}
+                </p>
+              </div>
+              <div className="inline-flex flex-wrap items-center gap-2 text-xs sm:text-sm text-white/80">
+                <Shield className="h-4 w-4" />
+                <span className="font-medium">
+                  Ваша роль — {userProfile?.role ? USER_ROLE_LABELS[userProfile.role] : 'Не определена'}
+                </span>
+              </div>
+            </div>
+            <div className="flex flex-col items-start sm:items-end gap-3 text-right">
+              <div className="flex items-center gap-3 rounded-2xl border border-white/30 bg-white/10 px-4 py-3 backdrop-blur-sm">
+                <Calendar className="h-5 w-5 text-white" />
+                <div className="text-sm font-medium text-white">
+                  {new Date().toLocaleDateString('ru-RU', {
+                    weekday: 'long',
+                    day: 'numeric',
+                    month: 'long'
+                  })}
+                </div>
+              </div>
+              <p className="text-xs text-white/70">
+                Обновлено в {new Date().toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' })}
+              </p>
             </div>
           </div>
-          <div className="flex items-center space-x-3 mt-2 sm:mt-0">
-            <div className="flex items-center space-x-2 bg-white/20 backdrop-blur-sm rounded-xl px-3 py-2 border border-white/30">
-              <Calendar size={16} className="text-white/90" />
-              <span className="text-sm font-medium text-white">
-                {new Date().toLocaleDateString('ru-RU', {
-                  weekday: 'short',
-                  day: 'numeric',
-                  month: 'long'
-                })}
-              </span>
+        </section>
+
+        {quickActions.length > 0 && (
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h2 className="text-base sm:text-lg font-semibold text-slate-900">Быстрые действия</h2>
             </div>
+            <div className="flex gap-4 overflow-x-auto px-0 -mx-4 sm:-mx-6 lg:-mx-8 sm:px-0 md:overflow-visible scrollbar-hide">
+              <div className="flex gap-4 px-4 sm:px-6 lg:px-8 md:px-0 md:flex-wrap md:w-full">
+                {quickActions.map((action) => (
+                  <QuickActionCard key={action.id} action={action} />
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section className="space-y-3">
+          <h2 className="text-base sm:text-lg font-semibold text-slate-900">Ваш прогресс</h2>
+          <div className="flex gap-4 overflow-x-auto -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 md:grid md:grid-cols-2 xl:grid-cols-4 md:gap-6 md:overflow-visible md:-mx-0 md:px-0 scrollbar-hide">
+            {role !== 'expert' && (
+              <>
+                <StatsCard
+                  title="Активные мероприятия"
+                  value={stats.activeEvents}
+                  icon={<BookOpen size={20} />}
+                />
+                <StatsCard
+                  title="Завершенные курсы"
+                  value={stats.completedCourses}
+                  icon={<Award size={20} />}
+                />
+              </>
+            )}
+            {role && ['administrator', 'moderator', 'trainer'].includes(role) && (
+              <StatsCard
+                title="Участники"
+                value={stats.totalParticipants}
+                icon={<Users size={20} />}
+              />
+            )}
+            {role && ['administrator', 'moderator', 'trainer'].includes(role) && (
+              <StatsCard
+                title="Средняя оценка"
+                value={stats.averageRating > 0 ? stats.averageRating.toFixed(1) : '—'}
+                icon={<TrendingUp size={20} />}
+              />
+            )}
+            {role === 'expert' && (
+              <StatsCard
+                title="Активные экзамены"
+                value={stats.activeEvents}
+                icon={<CheckCircle2 size={20} />}
+              />
+            )}
           </div>
-        </div>
-        {/* Декоративные элементы */}
-        <div className="absolute -top-4 -right-4 w-24 h-24 bg-white/10 rounded-full pointer-events-none" />
-        <div className="absolute -bottom-6 -left-6 w-32 h-32 bg-white/5 rounded-full pointer-events-none" />
-        <div className="absolute top-1/2 -right-8 w-16 h-16 bg-white/5 rounded-full pointer-events-none" />
-      </section>
+        </section>
 
-      {/* Stats Grid */}
-      <section className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-6">
-        {/* Для экспертов не показываем карточки статистики */}
-        {userProfile?.role !== 'expert' && (
-          <>
-            <StatsCard
-              title="Активные мероприятия"
-              value={stats.activeEvents}
-              icon={<BookOpen size={22} />}
-            />
-            <StatsCard
-              title="Завершенные курсы"
-              value={stats.completedCourses}
-              icon={<Award size={22} />}
-            />
-          </>
-        )}
-        {userProfile?.role && ['administrator', 'moderator', 'trainer'].includes(userProfile.role) && (
-          <StatsCard
-            title="Участники"
-            value={stats.totalParticipants}
-            icon={<Users size={22} />}
-          />
-        )}
-        {userProfile?.role && ['administrator', 'moderator', 'trainer'].includes(userProfile.role) && (
-          <StatsCard
-            title="Средняя оценка"
-            value={stats.averageRating > 0 ? stats.averageRating.toFixed(1) : '—'}
-            icon={<TrendingUp size={22} />}
-          />
-        )}
-      </section>
-
-      {/* Achievements Section - временно отключено */}
-      {/* <AchievementSection /> */}
-
-      {/* Upcoming Events as Cards */}
-      <section className="mt-4">
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="text-lg sm:text-xl font-semibold text-gray-900">
-            Ближайшие мероприятия
-          </h2>
-          <div className="flex items-center gap-2">
-            <button 
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-slate-900">Ближайшие мероприятия</h2>
+            <button
               onClick={() => fetchUserEvents(true)}
               disabled={eventsLoading}
-              className="inline-flex items-center gap-1.5 text-slate-400 hover:text-slate-600 transition-colors text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed bg-slate-50/50 hover:bg-slate-100/80 px-2 py-1.5 rounded-lg border border-slate-200/60 hover:border-slate-300/80"
+              className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-500 transition-colors duration-200 hover:text-slate-700 hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <RefreshCw className={`w-3.5 h-3.5 ${eventsLoading ? 'animate-spin' : ''}`} />
+              <RefreshCw className={`h-3.5 w-3.5 ${eventsLoading ? 'animate-spin' : ''}`} />
               Обновить
             </button>
           </div>
-        </div>
-        
-        {eventsLoading ? (
-          <div className="flex items-center justify-center py-12 mb-32 md:mb-20">
-            <div className="flex flex-col items-center">
-              <div className="w-8 h-8 border-3 border-[#06A478] border-t-transparent rounded-full animate-spin mb-4"></div>
-              <p className="text-slate-600 font-medium">Загрузка мероприятий...</p>
+
+          {eventsLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="flex flex-col items-center gap-3 text-slate-500">
+                <div className="w-8 h-8 border-[3px] border-emerald-500 border-t-transparent rounded-full animate-spin"></div>
+                <p className="text-sm font-medium">Загружаем мероприятия…</p>
+              </div>
             </div>
-          </div>
-        ) : eventsError ? (
-          <div className="text-center py-12 mb-32 md:mb-20">
-            <XCircle className="mx-auto text-red-500 mb-4" size={48} />
-            <p className="text-red-600 mb-4 font-medium">{eventsError}</p>
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <button 
+          ) : eventsError ? (
+            <div className="flex flex-col items-center gap-4 rounded-3xl border border-red-100 bg-red-50/60 px-6 py-8 text-center text-red-600">
+              <XCircle className="h-10 w-10" />
+              <p className="text-sm font-semibold">{eventsError}</p>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <button
+                  onClick={() => fetchUserEvents(true)}
+                  className="inline-flex items-center gap-2 rounded-2xl bg-red-500 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-red-600"
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  Попробовать снова
+                </button>
+                <button
+                  onClick={() => fetchUserEvents()}
+                  className="inline-flex items-center gap-2 rounded-2xl border border-red-200 px-4 py-2 text-sm font-medium text-red-600 transition hover:bg-white/60"
+                >
+                  Загрузить из кэша
+                </button>
+              </div>
+            </div>
+          ) : upcomingEvents.length === 0 ? (
+            <div className="flex flex-col items-center gap-4 rounded-3xl border border-slate-200/70 bg-white/70 px-6 py-12 text-center">
+              <BookOpen size={48} className="text-slate-300" />
+              <div className="space-y-2">
+                <p className="text-sm font-semibold text-slate-700">У вас пока нет предстоящих мероприятий</p>
+                <p className="text-xs text-slate-500">Обратитесь к администратору, чтобы записаться и получить новые события</p>
+              </div>
+              <button
                 onClick={() => fetchUserEvents(true)}
-                className="inline-flex items-center px-4 py-2 bg-[#06A478] text-white rounded-2xl hover:bg-[#059669] transition-colors text-sm font-medium shadow-sm hover:shadow-md"
+                className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-50"
               >
-                <RefreshCw className="w-4 h-4 mr-2" />
-                Попробовать снова
-              </button>
-              <button 
-                onClick={() => fetchUserEvents()}
-                className="inline-flex items-center px-4 py-2 text-slate-600 border border-slate-300 rounded-2xl hover:bg-slate-50 transition-colors text-sm font-medium"
-              >
-                Загрузить из кэша
+                <RefreshCw className="h-4 w-4" />
+                Обновить
               </button>
             </div>
-          </div>
-        ) : upcomingEvents.length === 0 ? (
-          <div className="text-center py-12 mb-32 md:mb-20">
-            <BookOpen size={48} className="mx-auto text-slate-400 mb-4" />
-            <p className="text-slate-600 mb-2 font-medium">У вас пока нет предстоящих мероприятий</p>
-            <p className="text-sm text-slate-500 mb-6">Обратитесь к администратору для записи на мероприятия</p>
-            <button 
-              onClick={() => fetchUserEvents(true)}
-              className="inline-flex items-center px-4 py-2 text-slate-600 border border-slate-300 rounded-2xl hover:bg-slate-50 transition-colors text-sm font-medium"
-            >
-              <RefreshCw className="w-4 h-4 mr-2" />
-              Обновить
-            </button>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-32 md:mb-20 mt-4 md:mt-0" style={{ lineHeight: '1.2' }}>
-            {upcomingEvents.map((event) => (
-              <EventCard key={event.id} event={event} />
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* Bottom Navigation для мобильных */}
-
+          ) : (
+            <div className="flex gap-4 overflow-x-auto -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 md:grid md:grid-cols-2 xl:grid-cols-3 md:gap-6 md:overflow-visible md:-mx-0 md:px-0 scrollbar-hide">
+              {upcomingEvents.map((event) => (
+                <EventCard key={event.id} event={event} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the dashboard hero, quick actions, stats, and event cards with a mobile-first glassmorphism aesthetic
- add reusable quick action cards and enhanced event-card logic for experts and admins
- update loading, empty, and error states to feel like a native app experience

## Testing
- `npm run lint` *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da98e29b008323b283a6991ff8ca09

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mobile-first redesign of dashboard hero, quick actions, stats, and event cards with role-aware exam access and improved loading/error/empty states.
> 
> - **Frontend**:
>   - **Dashboard layout**: New mobile-first, glassmorphism styling with gradient/radial backgrounds; revamped hero with date and role badge.
>   - **Quick Actions**: Adds `QuickAction` type and `QuickActionCard`; renders role-based actions (`/events`, `/calendar`, experts get `/expert-schedule`, others `/testing`, admins get `/employees`).
>   - **Stats**: Redesigned `StatsCard` styles; role-aware metrics; experts see "Активные экзамены".
>   - **Events**:
>     - `EventCard` UI overhaul (status/type chips, location, date accent, shadows).
>     - Role-based behavior: hide non-exam items for experts; allow admins/assigned experts to open `/expert-exam/:id`; others open `/event/:id` via single CTA.
>     - Improved list layout (horizontal scroll on mobile).
>   - **States**: Updated loading spinners, and richer empty/error states with retry and cache options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8febdae71dfb2358d921541a3f6f5c3284ca8ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->