### PR TITLE
Align upcoming events grid with dashboard header

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -682,7 +682,7 @@ export function DashboardView() {
               </button>
             </div>
           ) : (
-            <div className="-mx-4 flex snap-x gap-4 overflow-x-auto px-4 scrollbar-hide sm:-mx-6 sm:px-6 md:grid md:grid-cols-2 md:gap-6 md:overflow-visible md:px-0 xl:grid-cols-3">
+            <div className="-mx-4 flex snap-x gap-4 overflow-x-auto px-4 scrollbar-hide sm:-mx-6 sm:px-6 md:grid md:grid-cols-2 md:gap-6 md:overflow-visible md:mx-0 md:px-0 xl:grid-cols-3">
               {upcomingEvents.map(event => (
                 <EventCard key={event.id} event={event} />
               ))}


### PR DESCRIPTION
## Summary
- align the upcoming events card grid with the dashboard header on desktop by resetting negative margins at the medium breakpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db95d359e8832394947d2c86bee4bf