### PR TITLE
Improve dashboard event card entrance animation

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -60,7 +60,7 @@ const TYPE_LABELS = {
 } as const;
 
 // Карточка мероприятия с визуальной идентикой
-function EventCard({ event }: { event: EventWithDetails }) {
+function EventCard({ event, animationDelay = 0 }: { event: EventWithDetails; animationDelay?: number }) {
   const { userProfile } = useAuth();
 
   // Развёрнутые комментарии на русском по требованию пользователя
@@ -144,8 +144,11 @@ function EventCard({ event }: { event: EventWithDetails }) {
     return typeColors[event.type || 'other'] || 'bg-slate-50 text-slate-700 ring-slate-200';
   }, [event.event_type?.name, event.type]);
 
-  return (
-    <article className="group relative flex h-full min-w-[260px] flex-col overflow-hidden rounded-[26px] border border-white/40 bg-white/70 p-5 shadow-[0_28px_60px_-36px_rgba(15,23,42,0.55)] backdrop-blur-2xl transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_48px_80px_-42px_rgba(15,23,42,0.45)] sm:min-w-0">
+    return (
+      <article
+        className="dashboard-card-enter group relative flex h-full min-w-[260px] flex-col overflow-hidden rounded-[26px] border border-white/40 bg-white/70 p-5 shadow-[0_28px_60px_-36px_rgba(15,23,42,0.55)] backdrop-blur-2xl transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_48px_80px_-42px_rgba(15,23,42,0.45)] sm:min-w-0"
+        style={{ animationDelay: `${animationDelay}ms` }}
+      >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(14,159,110,0.08),transparent_65%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
       <div className="relative flex h-full flex-col">
         <header className="mb-4 flex flex-shrink-0 items-start justify-between gap-3">
@@ -683,8 +686,8 @@ export function DashboardView() {
             </div>
           ) : (
             <div className="-mx-4 flex snap-x gap-4 overflow-x-auto px-4 scrollbar-hide sm:-mx-6 sm:px-6 md:grid md:grid-cols-2 md:gap-6 md:overflow-visible md:mx-0 md:px-0 xl:grid-cols-3">
-              {upcomingEvents.map(event => (
-                <EventCard key={event.id} event={event} />
+              {upcomingEvents.map((event, index) => (
+                <EventCard key={event.id} event={event} animationDelay={index * 70} />
               ))}
             </div>
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,24 @@
   }
 }
 
+@keyframes dashboardCardEnter {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 18px, 0) scale(0.97);
+    filter: blur(6px);
+  }
+  60% {
+    opacity: 1;
+    transform: translate3d(0, -2px, 0) scale(1.01);
+    filter: blur(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: blur(0);
+  }
+}
+
 @font-face {
   font-family: 'Mabry';
   src: url('./assets/fonts/MABRYPRO-REGULAR.TTF') format('truetype');
@@ -169,6 +187,17 @@
   
   .btn-mobile-sm {
     @apply min-h-[44px] px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 touch-target;
+  }
+}
+
+.dashboard-card-enter {
+  animation: dashboardCardEnter 0.55s cubic-bezier(0.16, 1, 0.3, 1) both;
+  will-change: transform, opacity, filter;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-card-enter {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- add staggered entrance animation for upcoming event cards to avoid delayed appearance
- define dashboard-specific keyframes with reduced-motion fallback to keep transitions smooth

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9a3466d08323b490d1c9058c90f0